### PR TITLE
Implement quit command handling

### DIFF
--- a/src/edu/kit/kastle/filesorter/Application.java
+++ b/src/edu/kit/kastle/filesorter/Application.java
@@ -1,5 +1,7 @@
 package edu.kit.kastle.filesorter;
 
+import edu.kit.kastle.filesorter.view.CommandHandler;
+
 /**
  * The class offering the entry point for the application.
  *
@@ -27,5 +29,7 @@ public final class Application {
             return;
         }
         System.out.println(WELCOME_MESSAGE);
+        CommandHandler commandHandler = new CommandHandler();
+        commandHandler.run();
     }
 }

--- a/src/edu/kit/kastle/filesorter/view/CommandHandler.java
+++ b/src/edu/kit/kastle/filesorter/view/CommandHandler.java
@@ -1,5 +1,18 @@
 package edu.kit.kastle.filesorter.view;
 
+import edu.kit.kastle.filesorter.view.command.Command;
+import edu.kit.kastle.filesorter.view.command.QuitCommand;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 /**
  * This class handles the user input and executes the commands.
  *
@@ -9,7 +22,29 @@ public class CommandHandler {
     private static final String ERROR_PREFIX = "ERROR: ";
     private static final String ERROR_COMMAND_NOT_FOUND_FORMAT = "Command '%s' not found";
 
-    private CommandHandler() {
+    private final Map<String, Command> commands = new HashMap<>();
+    private final BufferedReader reader;
+    private final PrintStream output;
+    private boolean running;
+
+    /**
+     * Creates a command handler that reads from {@link System#in} and writes to {@link System#out}.
+     */
+    public CommandHandler() {
+        this(System.in, System.out);
+    }
+
+    /**
+     * Creates a command handler with the given input and output streams.
+     *
+     * @param input  the input stream to read commands from
+     * @param output the output stream to write results to
+     */
+    public CommandHandler(InputStream input, PrintStream output) {
+        Objects.requireNonNull(input, "input");
+        this.output = Objects.requireNonNull(output, "output");
+        this.reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+        this.running = true;
         this.initializeCommands();
     }
 
@@ -18,6 +53,86 @@ public class CommandHandler {
     }
 
     private void addCommand(Command command) {
-        this.commands.add(command);
+        Command nonNullCommand = Objects.requireNonNull(command, "command");
+        this.commands.put(nonNullCommand.getCommandName(), nonNullCommand);
+    }
+
+    /**
+     * Starts processing user input until the application is instructed to quit or the input stream ends.
+     */
+    public void run() {
+        while (this.running) {
+            String line = this.readLine();
+            if (line == null) {
+                break;
+            }
+            if (line.isBlank()) {
+                continue;
+            }
+            Result result = this.handleCommand(line);
+            this.printResult(result);
+        }
+    }
+
+    private String readLine() {
+        try {
+            return this.reader.readLine();
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to read from input", exception);
+        }
+    }
+
+    /**
+     * Handles a single command line.
+     *
+     * @param input the user input
+     * @return the result of the command execution
+     */
+    public Result handleCommand(String input) {
+        Objects.requireNonNull(input, "input");
+        String trimmed = input.trim();
+        if (trimmed.isEmpty()) {
+            return Result.success();
+        }
+        String[] tokens = trimmed.split("\\s+");
+        String commandName = tokens[0];
+        Command command = this.commands.get(commandName);
+        if (command == null) {
+            return Result.error(String.format(ERROR_COMMAND_NOT_FOUND_FORMAT, commandName));
+        }
+        String[] arguments = Arrays.copyOfRange(tokens, 1, tokens.length);
+        return command.execute(arguments);
+    }
+
+    private void printResult(Result result) {
+        if (result == null) {
+            return;
+        }
+        String message = result.getMessage();
+        if (message == null || message.isEmpty()) {
+            return;
+        }
+        if (result.getType() == ResultType.FAILURE) {
+            this.output.println(ERROR_PREFIX + message);
+        } else {
+            this.output.println(message);
+        }
+        this.output.flush();
+    }
+
+    /**
+     * Stops the command handler. Subsequent calls to {@link #run()} will exit the processing loop.
+     */
+    public void stop() {
+        this.running = false;
+    }
+
+    /**
+     * Returns whether the handler is still processing commands.
+     *
+     * @return {@code true} if the handler is processing commands; {@code false} otherwise
+     */
+    public boolean isRunning() {
+        return this.running;
     }
 }

--- a/src/edu/kit/kastle/filesorter/view/command/Command.java
+++ b/src/edu/kit/kastle/filesorter/view/command/Command.java
@@ -1,5 +1,11 @@
 package edu.kit.kastle.filesorter.view.command;
 
+import edu.kit.kastle.filesorter.view.Result;
+import java.util.Objects;
+
+/**
+ * Represents a user command.
+ */
 public abstract class Command {
 
     private static final String INVALID_ARGUMENTS_ERROR_FORMAT = "%s command takes %d parameters.";
@@ -14,7 +20,39 @@ public abstract class Command {
      * @param expectedArgumentLength the number of arguments that the command expects
      */
     protected Command(String commandName, int expectedArgumentLength) {
-        this.commandName = commandName;
+        this.commandName = Objects.requireNonNull(commandName, "commandName");
         this.expectedArgumentLength = expectedArgumentLength;
     }
+
+    /**
+     * Returns the name of the command.
+     *
+     * @return the command name
+     */
+    public String getCommandName() {
+        return this.commandName;
+    }
+
+    /**
+     * Executes the command with the given arguments.
+     *
+     * @param arguments the arguments supplied by the user
+     * @return the result of the command execution
+     */
+    public final Result execute(String[] arguments) {
+        Objects.requireNonNull(arguments, "arguments");
+        if (arguments.length != this.expectedArgumentLength) {
+            return Result.error(String.format(INVALID_ARGUMENTS_ERROR_FORMAT, this.commandName, this.expectedArgumentLength));
+        }
+        return this.executeCommand(arguments);
+    }
+
+    /**
+     * Executes the command. Implementations can assume that the number of arguments matches
+     * {@link #expectedArgumentLength}.
+     *
+     * @param arguments the arguments passed to the command
+     * @return the result of the command execution
+     */
+    protected abstract Result executeCommand(String[] arguments);
 }

--- a/src/edu/kit/kastle/filesorter/view/command/QuitCommand.java
+++ b/src/edu/kit/kastle/filesorter/view/command/QuitCommand.java
@@ -1,0 +1,30 @@
+package edu.kit.kastle.filesorter.view.command;
+
+import edu.kit.kastle.filesorter.view.CommandHandler;
+import edu.kit.kastle.filesorter.view.Result;
+
+/**
+ * Command that terminates the application.
+ */
+public class QuitCommand extends Command {
+
+    private static final String COMMAND_NAME = "quit";
+
+    private final CommandHandler commandHandler;
+
+    /**
+     * Creates a new quit command.
+     *
+     * @param commandHandler the command handler managing the application lifecycle
+     */
+    public QuitCommand(CommandHandler commandHandler) {
+        super(COMMAND_NAME, 0);
+        this.commandHandler = commandHandler;
+    }
+
+    @Override
+    protected Result executeCommand(String[] arguments) {
+        this.commandHandler.stop();
+        return Result.success();
+    }
+}


### PR DESCRIPTION
## Summary
- add an interactive command handler that reads commands from the configured input stream
- expose the base command behavior and register a quit command that stops the handler loop
- start the command handler from the application entry point so the program waits for commands

## Testing
- mkdir -p out && javac -d out $(find src -name '*.java') && printf "quit\n" | java -cp out edu.kit.kastle.filesorter.Application


------
https://chatgpt.com/codex/tasks/task_e_68c87cc26e7883268751d40615ff3c0b