### PR TITLE
Harden tokenization result access and strategy parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Programmieraufgabe - Repository Vorlage
 Im Verzeichnis src/ sind alle Quelltextdateien und Pakete abzulegen.
 Elemente außerhalb des src/ Verzeichnisses werden nicht kompiliert und folglich nicht berücksichtigt.
+
+## Tokenization-Befehl
+Der Sequenzabgleich unterstützt nun den Befehl `tokenization <id> <strategy>`, um den in der
+Anwendung gespeicherten Text unter der Kennung `<id>` zu zerlegen. Das Ergebnis wird als
+`~`-separierte Liste von Token ausgegeben.
+
+Folgende Strategien stehen zur Auswahl:
+
+* `CHAR`: jeder Unicode-Codepunkt wird als einzelnes Token zurückgegeben.
+* `WORD`: trennt anhand von Leerraum. Satzzeichen bleiben an den Wörtern haften.
+* `SMART`: trennt anhand von Leerraum und gibt Satzzeichen (mit Ausnahme von Apostroph und Bindestrich
+  zwischen alphanumerischen Zeichen) als eigene Token zurück.

--- a/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
+++ b/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -25,6 +26,9 @@ public class SequenceMatcher {
     private static final String ERROR_COULD_NOT_READ_FILE = "Could not read file.";
     private static final String MESSAGE_LOADED = "Loaded %s";
     private static final String MESSAGE_UPDATED = "Updated %s";
+    private static final String ERROR_UNKNOWN_IDENTIFIER = "No text stored for identifier '%s'.";
+    private static final String ERROR_MISSING_IDENTIFIER = "No identifier provided.";
+    private static final String ERROR_MISSING_STRATEGY = "No tokenization strategy provided.";
 
     private final Map<String, LoadedText> loadedTexts = new LinkedHashMap<>();
 
@@ -93,6 +97,30 @@ public class SequenceMatcher {
         Objects.requireNonNull(text);
 
         return storeText(identifier, null, text);
+    }
+
+    /**
+     * Tokenizes the stored text identified by the provided identifier using the given strategy.
+     *
+     * @param identifier the identifier of the text to tokenize
+     * @param strategy the tokenization strategy to apply
+     * @return the result of the tokenization attempt
+     */
+    public TokenizationResult tokenize(String identifier, TokenizationStrategy strategy) {
+        if (identifier == null) {
+            return TokenizationResult.error(ERROR_MISSING_IDENTIFIER);
+        }
+        if (strategy == null) {
+            return TokenizationResult.error(ERROR_MISSING_STRATEGY);
+        }
+
+        LoadedText loadedText = this.loadedTexts.get(identifier);
+        if (loadedText == null) {
+            return TokenizationResult.error(ERROR_UNKNOWN_IDENTIFIER.formatted(identifier));
+        }
+
+        List<String> tokens = strategy.tokenize(loadedText.content());
+        return TokenizationResult.success(tokens);
     }
 
     private Result storeText(String identifier, Path source, String content) {

--- a/src/edu/kit/kastel/filesorter/model/TokenizationResult.java
+++ b/src/edu/kit/kastel/filesorter/model/TokenizationResult.java
@@ -11,6 +11,8 @@ import java.util.Objects;
  *
  * @param tokens the produced tokens (empty when an error occurred)
  * @param errorMessage the error message in case of a failure; {@code null} for successful results
+ *
+ * @author ugsrv
  */
 public record TokenizationResult(List<String> tokens, String errorMessage) {
 

--- a/src/edu/kit/kastel/filesorter/model/TokenizationResult.java
+++ b/src/edu/kit/kastel/filesorter/model/TokenizationResult.java
@@ -1,0 +1,50 @@
+package edu.kit.kastel.filesorter.model;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Result of a tokenization operation executed by the model.
+ *
+ * <p>A result either contains the successfully generated tokens or provides an error message
+ * explaining why tokenization could not be performed.</p>
+ *
+ * @param tokens the produced tokens (empty when an error occurred)
+ * @param errorMessage the error message in case of a failure; {@code null} for successful results
+ */
+public record TokenizationResult(List<String> tokens, String errorMessage) {
+
+    /**
+     * Creates a successful tokenization result.
+     *
+     * @param tokens the generated tokens
+     * @return the success result
+     */
+    public static TokenizationResult success(List<String> tokens) {
+        return new TokenizationResult(List.copyOf(tokens), null);
+    }
+
+    /**
+     * Creates a failing tokenization result.
+     *
+     * @param errorMessage the error description
+     * @return the failure result
+     */
+    public static TokenizationResult error(String errorMessage) {
+        return new TokenizationResult(List.of(), Objects.requireNonNull(errorMessage));
+    }
+
+    /**
+     * Returns whether the tokenization was successful.
+     *
+     * @return {@code true} if the tokenization succeeded, {@code false} otherwise
+     */
+    public boolean isSuccess() {
+        return this.errorMessage == null;
+    }
+
+    @Override
+    public List<String> tokens() {
+        return List.copyOf(this.tokens);
+    }
+}

--- a/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
+++ b/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
@@ -19,6 +19,8 @@ import java.util.Objects;
  *     tokens.</li>
  * </ul>
  * </p>
+ *
+ * @author ugsrv
  */
 public enum TokenizationStrategy {
     /**
@@ -72,7 +74,7 @@ public enum TokenizationStrategy {
                 } else if (Character.isLetterOrDigit(current) || isWordConnector(text, index)) {
                     currentToken.append(current);
 
-                }else {
+                } else {
                     flushToken(tokens, currentToken);
                     tokens.add(String.valueOf(current));
                 }

--- a/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
+++ b/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
@@ -69,14 +69,13 @@ public enum TokenizationStrategy {
                 char current = text.charAt(index);
                 if (Character.isWhitespace(current)) {
                     flushToken(tokens, currentToken);
-                    continue;
-                }
-                if (Character.isLetterOrDigit(current) || isWordConnector(text, index)) {
+                } else if (Character.isLetterOrDigit(current) || isWordConnector(text, index)) {
                     currentToken.append(current);
-                    continue;
+
+                }else {
+                    flushToken(tokens, currentToken);
+                    tokens.add(String.valueOf(current));
                 }
-                flushToken(tokens, currentToken);
-                tokens.add(String.valueOf(current));
             }
             flushToken(tokens, currentToken);
             return tokens;
@@ -96,7 +95,7 @@ public enum TokenizationStrategy {
         }
 
         private static void flushToken(List<String> tokens, StringBuilder currentToken) {
-            if (currentToken.length() > 0) {
+            if (!currentToken.isEmpty()) {
                 tokens.add(currentToken.toString());
                 currentToken.setLength(0);
             }

--- a/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
+++ b/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
@@ -1,0 +1,146 @@
+package edu.kit.kastel.filesorter.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Enumeration of supported tokenization strategies.
+ *
+ * <p>Each strategy defines how a text should be split into tokens that can later be reused for
+ * matching or inspection purposes. The strategies are implemented as follows:
+ * <ul>
+ *     <li>{@link #CHAR}: splits the text into single Unicode characters.</li>
+ *     <li>{@link #WORD}: splits the text into words separated by whitespace. Punctuation marks
+ *     remain attached to the surrounding words.</li>
+ *     <li>{@link #SMART}: splits the text into words while treating punctuation marks (except
+ *     apostrophes and hyphen-minus characters occurring between letters or digits) as separate
+ *     tokens.</li>
+ * </ul>
+ * </p>
+ */
+public enum TokenizationStrategy {
+    /**
+     * Tokenization strategy that returns every character of the input text as a separate token.
+     */
+    CHAR {
+        @Override
+        public List<String> tokenize(String text) {
+            Objects.requireNonNull(text);
+            List<String> tokens = new ArrayList<>(text.length());
+            text.codePoints().forEach(codePoint -> tokens.add(new String(Character.toChars(codePoint))));
+            return tokens;
+        }
+    },
+    /**
+     * Tokenization strategy that splits the text based on whitespace characters.
+     */
+    WORD {
+        private static final String WORD_DELIMITER_REGEX = "\\s+";
+
+        @Override
+        public List<String> tokenize(String text) {
+            Objects.requireNonNull(text);
+            String[] split = text.split(WORD_DELIMITER_REGEX);
+            List<String> tokens = new ArrayList<>(split.length);
+            for (String token : split) {
+                if (!token.isEmpty()) {
+                    tokens.add(token);
+                }
+            }
+            return tokens;
+        }
+    },
+    /**
+     * Tokenization strategy that splits the text into words while keeping punctuation separate.
+     */
+    SMART {
+        private static final char APOSTROPHE = '\'';
+        private static final char HYPHEN_MINUS = '-';
+
+        @Override
+        public List<String> tokenize(String text) {
+            Objects.requireNonNull(text);
+            List<String> tokens = new ArrayList<>();
+            StringBuilder currentToken = new StringBuilder();
+
+            for (int index = 0; index < text.length(); index++) {
+                char current = text.charAt(index);
+                if (Character.isWhitespace(current)) {
+                    flushToken(tokens, currentToken);
+                    continue;
+                }
+                if (Character.isLetterOrDigit(current) || isWordConnector(text, index)) {
+                    currentToken.append(current);
+                    continue;
+                }
+                flushToken(tokens, currentToken);
+                tokens.add(String.valueOf(current));
+            }
+            flushToken(tokens, currentToken);
+            return tokens;
+        }
+
+        private static boolean isWordConnector(String text, int index) {
+            char connector = text.charAt(index);
+            if (connector != APOSTROPHE && connector != HYPHEN_MINUS) {
+                return false;
+            }
+            if (index == 0 || index >= text.length() - 1) {
+                return false;
+            }
+            char previous = text.charAt(index - 1);
+            char next = text.charAt(index + 1);
+            return Character.isLetterOrDigit(previous) && Character.isLetterOrDigit(next);
+        }
+
+        private static void flushToken(List<String> tokens, StringBuilder currentToken) {
+            if (currentToken.length() > 0) {
+                tokens.add(currentToken.toString());
+                currentToken.setLength(0);
+            }
+        }
+    };
+
+    /**
+     * Tokenizes the provided text.
+     *
+     * @param text the text to tokenize
+     * @return the tokens produced by the strategy
+     */
+    public abstract List<String> tokenize(String text);
+
+    /**
+     * Finds the tokenization strategy matching the provided name. Parsing is case insensitive and
+     * ignores surrounding whitespace.
+     *
+     * @param value the string representation of the strategy
+     * @return the matching strategy or {@code null} if no strategy matches the provided name
+     */
+    public static TokenizationStrategy findByName(String value) {
+        Objects.requireNonNull(value);
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        for (TokenizationStrategy strategy : values()) {
+            if (strategy.name().equals(normalized)) {
+                return strategy;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses the provided string into a {@link TokenizationStrategy}.
+     *
+     * @param value the string representation of the strategy
+     * @return the matching strategy
+     * @throws IllegalArgumentException if no matching strategy exists
+     */
+    public static TokenizationStrategy fromName(String value) {
+        TokenizationStrategy strategy = findByName(value);
+        if (strategy == null) {
+            throw new IllegalArgumentException("Unknown tokenization strategy: " + value);
+        }
+        return strategy;
+    }
+}

--- a/src/edu/kit/kastel/filesorter/view/command/ModelKeyword.java
+++ b/src/edu/kit/kastel/filesorter/view/command/ModelKeyword.java
@@ -1,6 +1,7 @@
 package edu.kit.kastel.filesorter.view.command;
 
 import edu.kit.kastel.filesorter.model.SequenceMatcher;
+import edu.kit.kastel.filesorter.model.TokenizationStrategy;
 
 import edu.kit.kastel.filesorter.view.Arguments;
 import edu.kit.kastel.filesorter.view.Command;
@@ -26,9 +27,15 @@ public enum ModelKeyword implements Keyword<SequenceMatcher> {
     /**
      * Keyword for the {@link Load} command.
      */
-    LOAD(arguments -> new Load(parsePath(arguments)));
+    LOAD(arguments -> new Load(parsePath(arguments))),
+
+    /**
+     * Keyword for the {@link Tokenization} command.
+     */
+    TOKENIZATION(arguments -> new Tokenization(arguments.parseString(), parseTokenizationStrategy(arguments)));
 
     private static final String ERROR_INVALID_PATH = "invalid path";
+    private static final String ERROR_INVALID_STRATEGY = "invalid strategy";
     private static final String VALUE_NAME_DELIMITER = "_";
     private final CommandProvider<SequenceMatcher> provider;
 
@@ -72,5 +79,15 @@ public enum ModelKeyword implements Keyword<SequenceMatcher> {
 
     private static String parseText(Arguments arguments) throws InvalidArgumentException {
         return arguments.parseRemaining();
+    }
+
+    private static TokenizationStrategy parseTokenizationStrategy(Arguments arguments)
+            throws InvalidArgumentException {
+        String strategyArgument = arguments.parseString();
+        TokenizationStrategy strategy = TokenizationStrategy.findByName(strategyArgument);
+        if (strategy == null) {
+            throw new InvalidArgumentException(ERROR_INVALID_STRATEGY);
+        }
+        return strategy;
     }
 }

--- a/src/edu/kit/kastel/filesorter/view/command/Tokenization.java
+++ b/src/edu/kit/kastel/filesorter/view/command/Tokenization.java
@@ -8,6 +8,8 @@ import edu.kit.kastel.filesorter.view.Result;
 
 /**
  * Command that retrieves the tokenization of a stored text from the {@link SequenceMatcher}.
+ *
+ * @author ugsrv
  */
 public class Tokenization implements Command<SequenceMatcher> {
 

--- a/src/edu/kit/kastel/filesorter/view/command/Tokenization.java
+++ b/src/edu/kit/kastel/filesorter/view/command/Tokenization.java
@@ -1,0 +1,38 @@
+package edu.kit.kastel.filesorter.view.command;
+
+import edu.kit.kastel.filesorter.model.SequenceMatcher;
+import edu.kit.kastel.filesorter.model.TokenizationResult;
+import edu.kit.kastel.filesorter.model.TokenizationStrategy;
+import edu.kit.kastel.filesorter.view.Command;
+import edu.kit.kastel.filesorter.view.Result;
+
+/**
+ * Command that retrieves the tokenization of a stored text from the {@link SequenceMatcher}.
+ */
+public class Tokenization implements Command<SequenceMatcher> {
+
+    private static final String TOKEN_SEPARATOR = "~";
+
+    private final String identifier;
+    private final TokenizationStrategy strategy;
+
+    /**
+     * Creates a new command instance.
+     *
+     * @param identifier the identifier of the stored text
+     * @param strategy the strategy to use for tokenization
+     */
+    public Tokenization(String identifier, TokenizationStrategy strategy) {
+        this.identifier = identifier;
+        this.strategy = strategy;
+    }
+
+    @Override
+    public Result execute(SequenceMatcher handle) {
+        TokenizationResult result = handle.tokenize(this.identifier, this.strategy);
+        if (!result.isSuccess()) {
+            return Result.error(result.errorMessage());
+        }
+        return Result.success(String.join(TOKEN_SEPARATOR, result.tokens()));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `TokenizationResult.tokens()` returns a defensive copy instead of exposing the underlying list
- add a safe lookup helper for tokenization strategies and reuse it from the CLI keyword without catching IllegalArgumentException

## Testing
- `mvn -q -DskipTests test` *(fails: unable to resolve Maven plugins because Maven Central is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cc367a2e7c83268c2df094da483332