### PR TITLE
Implement analyze command and analysis result handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Folgende Strategien stehen zur Auswahl:
 * `WORD`: trennt anhand von Leerraum. Satzzeichen bleiben an den Wörtern haften.
 * `SMART`: trennt anhand von Leerraum und gibt Satzzeichen (mit Ausnahme von Apostroph und Bindestrich
   zwischen alphanumerischen Zeichen) als eigene Token zurück.
+
+## Analyze-Befehl
+Mit dem Befehl `analyze <strategy> <minMatchLength>` werden alle aktuell geladenen Texte mit der
+gewählten Tokenisierungsstrategie verglichen. Für jedes Textpaar werden dabei nur zusammenhängende
+Übereinstimmungen berücksichtigt, deren Länge mindestens `minMatchLength` Token beträgt. Nach
+Abschluss der Analyse gibt die Anwendung die benötigte Zeit im Format `Analysis took <dur> ms`
+aus und stellt das Ergebnis für weitere Befehle bereit.

--- a/src/edu/kit/kastel/filesorter/model/AnalysisMatch.java
+++ b/src/edu/kit/kastel/filesorter/model/AnalysisMatch.java
@@ -10,6 +10,8 @@ import java.util.Objects;
  * @param secondIdentifier the identifier of the second text containing the match
  * @param secondIndex the starting token index of the match within the second text
  * @param length the length of the match measured in tokens
+ *
+ * @author ugsrv
  */
 public record AnalysisMatch(String firstIdentifier, int firstIndex,
         String secondIdentifier, int secondIndex, int length) {

--- a/src/edu/kit/kastel/filesorter/model/AnalysisMatch.java
+++ b/src/edu/kit/kastel/filesorter/model/AnalysisMatch.java
@@ -23,13 +23,17 @@ public record AnalysisMatch(String firstIdentifier, int firstIndex,
     private static final String ERROR_NON_POSITIVE_LENGTH = "length must be positive.";
 
     /**
-     * Creates a new match instance.
+     * Constructs a new instance of the AnalysisMatch class, representing a contiguous matching
+     * token sequence between two texts.
      *
      * @param firstIdentifier the identifier of the first text containing the match
      * @param firstIndex the starting token index of the match within the first text
      * @param secondIdentifier the identifier of the second text containing the match
      * @param secondIndex the starting token index of the match within the second text
      * @param length the length of the match measured in tokens
+     * @throws NullPointerException if {@code firstIdentifier} or {@code secondIdentifier} is {@code null}
+     * @throws IllegalArgumentException if {@code firstIndex} or {@code secondIndex} is negative,
+     *                                  or if {@code length} is less than 1
      */
     public AnalysisMatch {
         Objects.requireNonNull(firstIdentifier, ERROR_FIRST_IDENTIFIER_NULL);

--- a/src/edu/kit/kastel/filesorter/model/AnalysisMatch.java
+++ b/src/edu/kit/kastel/filesorter/model/AnalysisMatch.java
@@ -1,0 +1,45 @@
+package edu.kit.kastel.filesorter.model;
+
+import java.util.Objects;
+
+/**
+ * Represents a contiguous matching token sequence between two texts.
+ *
+ * @param firstIdentifier the identifier of the first text containing the match
+ * @param firstIndex the starting token index of the match within the first text
+ * @param secondIdentifier the identifier of the second text containing the match
+ * @param secondIndex the starting token index of the match within the second text
+ * @param length the length of the match measured in tokens
+ */
+public record AnalysisMatch(String firstIdentifier, int firstIndex,
+        String secondIdentifier, int secondIndex, int length) {
+
+    private static final String ERROR_FIRST_IDENTIFIER_NULL = "firstIdentifier must not be null.";
+    private static final String ERROR_SECOND_IDENTIFIER_NULL = "secondIdentifier must not be null.";
+    private static final String ERROR_NEGATIVE_FIRST_INDEX = "firstIndex must be non-negative.";
+    private static final String ERROR_NEGATIVE_SECOND_INDEX = "secondIndex must be non-negative.";
+    private static final String ERROR_NON_POSITIVE_LENGTH = "length must be positive.";
+
+    /**
+     * Creates a new match instance.
+     *
+     * @param firstIdentifier the identifier of the first text containing the match
+     * @param firstIndex the starting token index of the match within the first text
+     * @param secondIdentifier the identifier of the second text containing the match
+     * @param secondIndex the starting token index of the match within the second text
+     * @param length the length of the match measured in tokens
+     */
+    public AnalysisMatch {
+        Objects.requireNonNull(firstIdentifier, ERROR_FIRST_IDENTIFIER_NULL);
+        Objects.requireNonNull(secondIdentifier, ERROR_SECOND_IDENTIFIER_NULL);
+        if (firstIndex < 0) {
+            throw new IllegalArgumentException(ERROR_NEGATIVE_FIRST_INDEX);
+        }
+        if (secondIndex < 0) {
+            throw new IllegalArgumentException(ERROR_NEGATIVE_SECOND_INDEX);
+        }
+        if (length < 1) {
+            throw new IllegalArgumentException(ERROR_NON_POSITIVE_LENGTH);
+        }
+    }
+}

--- a/src/edu/kit/kastel/filesorter/model/AnalysisResult.java
+++ b/src/edu/kit/kastel/filesorter/model/AnalysisResult.java
@@ -1,0 +1,86 @@
+package edu.kit.kastel.filesorter.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents the result of a text analysis.
+ *
+ * <p>The result stores the configuration that has been used for the analysis as well as the
+ * produced matches and tokenizations. Instances of this class are immutable.</p>
+ */
+public final class AnalysisResult {
+
+    private static final String ERROR_INVALID_MIN_MATCH_LENGTH = "minMatchLength must be positive.";
+
+    private final TokenizationStrategy strategy;
+    private final int minMatchLength;
+    private final Map<String, List<String>> tokenizedTexts;
+    private final List<AnalysisMatch> matches;
+
+    /**
+     * Creates a new analysis result.
+     *
+     * @param strategy the strategy that was used to tokenize the texts
+     * @param minMatchLength the minimum length a match must have to be included in the result
+     * @param tokenizedTexts the tokenized representation of all texts considered for the analysis
+     * @param matches the matches that have been found between the texts
+     */
+    public AnalysisResult(TokenizationStrategy strategy, int minMatchLength,
+            Map<String, List<String>> tokenizedTexts, List<AnalysisMatch> matches) {
+        this.strategy = Objects.requireNonNull(strategy);
+        if (minMatchLength < 1) {
+            throw new IllegalArgumentException(ERROR_INVALID_MIN_MATCH_LENGTH);
+        }
+        Objects.requireNonNull(tokenizedTexts);
+        Objects.requireNonNull(matches);
+
+        Map<String, List<String>> tokenCopy = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : tokenizedTexts.entrySet()) {
+            tokenCopy.put(entry.getKey(), List.copyOf(entry.getValue()));
+        }
+
+        this.minMatchLength = minMatchLength;
+        this.tokenizedTexts = Collections.unmodifiableMap(tokenCopy);
+        this.matches = List.copyOf(matches);
+    }
+
+    /**
+     * Returns the strategy that was used for tokenizing the texts.
+     *
+     * @return the tokenization strategy used for the analysis
+     */
+    public TokenizationStrategy strategy() {
+        return this.strategy;
+    }
+
+    /**
+     * Returns the minimum number of tokens a match must contain to be included in the result.
+     *
+     * @return the minimum match length in tokens
+     */
+    public int minMatchLength() {
+        return this.minMatchLength;
+    }
+
+    /**
+     * Returns the tokenized representations of the analyzed texts.
+     *
+     * @return an unmodifiable view of the tokenized texts
+     */
+    public Map<String, List<String>> tokenizedTexts() {
+        return this.tokenizedTexts;
+    }
+
+    /**
+     * Returns the matches that have been found during the analysis.
+     *
+     * @return the matches produced by the analysis
+     */
+    public List<AnalysisMatch> matches() {
+        return this.matches;
+    }
+}

--- a/src/edu/kit/kastel/filesorter/model/AnalysisResult.java
+++ b/src/edu/kit/kastel/filesorter/model/AnalysisResult.java
@@ -10,7 +10,9 @@ import java.util.Objects;
  * Represents the result of a text analysis.
  *
  * <p>The result stores the configuration that has been used for the analysis as well as the
- * produced matches and tokenizations. Instances of this class are immutable.</p>
+ * produced matches and tokenization. Instances of this class are immutable.</p>
+ *
+ * @author ugsrv
  */
 public final class AnalysisResult {
 
@@ -22,12 +24,15 @@ public final class AnalysisResult {
     private final List<AnalysisMatch> matches;
 
     /**
-     * Creates a new analysis result.
+     * Constructs an immutable object representing the result of a text analysis.
      *
-     * @param strategy the strategy that was used to tokenize the texts
-     * @param minMatchLength the minimum length a match must have to be included in the result
-     * @param tokenizedTexts the tokenized representation of all texts considered for the analysis
-     * @param matches the matches that have been found between the texts
+     * @param strategy the tokenization strategy used for splitting texts into tokens
+     * @param minMatchLength the minimum number of tokens a match must contain to be included in the result
+     * @param tokenizedTexts a map containing the tokenized representations of analyzed texts,
+     *                       where keys are identifiers for the texts and values are the lists of tokens
+     * @param matches a list of matches found during text analysis
+     * @throws NullPointerException if {@code strategy}, {@code tokenizedTexts}, or {@code matches} is {@code null}
+     * @throws IllegalArgumentException if {@code minMatchLength} is less than 1
      */
     public AnalysisResult(TokenizationStrategy strategy, int minMatchLength,
             Map<String, List<String>> tokenizedTexts, List<AnalysisMatch> matches) {

--- a/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
+++ b/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
@@ -33,7 +33,7 @@ public class SequenceMatcher {
     private static final String ERROR_MISSING_IDENTIFIER = "No identifier provided.";
     private static final String ERROR_MISSING_STRATEGY = "No tokenization strategy provided.";
     private static final String ERROR_INVALID_MIN_MATCH_LENGTH = "Minimum match length must be positive.";
-    private static final String MESSAGE_ANALYSIS_TOOK = "Analysis took %d ms";
+    private static final String MESSAGE_ANALYSIS_TOOK = "Analysis took %dms";
 
     private final Map<String, LoadedText> loadedTexts = new LinkedHashMap<>();
     private AnalysisResult lastAnalysisResult;

--- a/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
+++ b/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
@@ -199,8 +199,8 @@ public class SequenceMatcher {
     private static int determineMatchLength(List<String> firstTokens, List<String> secondTokens, int firstIndex,
             int secondIndex) {
         int length = 0;
-        while (firstIndex + length < firstTokens.size() && secondIndex + length < secondTokens.size()
-                && firstTokens.get(firstIndex + length).equals(secondTokens.get(secondIndex + length))) {
+        for (; firstIndex + length < firstTokens.size() && secondIndex + length < secondTokens.size()
+                     && firstTokens.get(firstIndex + length).equals(secondTokens.get(secondIndex + length)); length++) {
             length++;
         }
         return length;
@@ -208,10 +208,7 @@ public class SequenceMatcher {
 
     private static boolean isStartOfMatch(List<String> firstTokens, List<String> secondTokens, int firstIndex,
             int secondIndex) {
-        if (firstIndex == 0 || secondIndex == 0) {
-            return true;
-        }
-        return !firstTokens.get(firstIndex - 1).equals(secondTokens.get(secondIndex - 1));
+        return firstIndex == 0 || secondIndex == 0 || !firstTokens.get(firstIndex - 1).equals(secondTokens.get(secondIndex - 1));
     }
 
     private Result storeText(String identifier, Path source, String content) {

--- a/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
+++ b/src/edu/kit/kastel/filesorter/model/SequenceMatcher.java
@@ -7,10 +7,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Represents the application's model storing the texts that are available for comparison.
@@ -29,8 +32,11 @@ public class SequenceMatcher {
     private static final String ERROR_UNKNOWN_IDENTIFIER = "No text stored for identifier '%s'.";
     private static final String ERROR_MISSING_IDENTIFIER = "No identifier provided.";
     private static final String ERROR_MISSING_STRATEGY = "No tokenization strategy provided.";
+    private static final String ERROR_INVALID_MIN_MATCH_LENGTH = "Minimum match length must be positive.";
+    private static final String MESSAGE_ANALYSIS_TOOK = "Analysis took %d ms";
 
     private final Map<String, LoadedText> loadedTexts = new LinkedHashMap<>();
+    private AnalysisResult lastAnalysisResult;
 
     /**
      * Loads the contents of the file located at the provided {@link Path}. The file name is used as
@@ -121,6 +127,91 @@ public class SequenceMatcher {
 
         List<String> tokens = strategy.tokenize(loadedText.content());
         return TokenizationResult.success(tokens);
+    }
+
+    /**
+     * Executes a text analysis on all loaded texts using the provided strategy and minimum match length.
+     *
+     * @param strategy the strategy to use for tokenizing the texts prior to analysis
+     * @param minMatchLength the minimum length of a match measured in tokens
+     * @return the result of the analysis
+     */
+    public Result analyze(TokenizationStrategy strategy, int minMatchLength) {
+        if (strategy == null) {
+            return Result.error(ERROR_MISSING_STRATEGY);
+        }
+        if (minMatchLength < 1) {
+            return Result.error(ERROR_INVALID_MIN_MATCH_LENGTH);
+        }
+
+        long startTime = System.nanoTime();
+
+        Map<String, List<String>> tokenizedTexts = new LinkedHashMap<>();
+        for (LoadedText loadedText : this.loadedTexts.values()) {
+            tokenizedTexts.put(loadedText.identifier(), strategy.tokenize(loadedText.content()));
+        }
+
+        List<AnalysisMatch> matches = collectMatches(tokenizedTexts, minMatchLength);
+        this.lastAnalysisResult = new AnalysisResult(strategy, minMatchLength, tokenizedTexts, matches);
+
+        long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+        return Result.success(MESSAGE_ANALYSIS_TOOK.formatted(durationMs));
+    }
+
+    /**
+     * Returns the result of the most recent analysis.
+     *
+     * @return the last analysis result or {@code null} if no analysis has been executed yet
+     */
+    public AnalysisResult getLastAnalysisResult() {
+        return this.lastAnalysisResult;
+    }
+
+    private static List<AnalysisMatch> collectMatches(Map<String, List<String>> tokenizedTexts, int minMatchLength) {
+        List<AnalysisMatch> matches = new ArrayList<>();
+        List<Entry<String, List<String>>> entries = new ArrayList<>(tokenizedTexts.entrySet());
+        for (int firstTextIndex = 0; firstTextIndex < entries.size(); firstTextIndex++) {
+            for (int secondTextIndex = firstTextIndex + 1; secondTextIndex < entries.size(); secondTextIndex++) {
+                matches.addAll(findMatches(entries.get(firstTextIndex), entries.get(secondTextIndex), minMatchLength));
+            }
+        }
+        return matches;
+    }
+
+    private static List<AnalysisMatch> findMatches(Entry<String, List<String>> firstEntry,
+            Entry<String, List<String>> secondEntry, int minMatchLength) {
+        List<AnalysisMatch> matches = new ArrayList<>();
+        List<String> firstTokens = firstEntry.getValue();
+        List<String> secondTokens = secondEntry.getValue();
+        for (int firstIndex = 0; firstIndex < firstTokens.size(); firstIndex++) {
+            for (int secondIndex = 0; secondIndex < secondTokens.size(); secondIndex++) {
+                int matchLength = determineMatchLength(firstTokens, secondTokens, firstIndex, secondIndex);
+                if (matchLength >= minMatchLength
+                        && isStartOfMatch(firstTokens, secondTokens, firstIndex, secondIndex)) {
+                    matches.add(new AnalysisMatch(firstEntry.getKey(), firstIndex,
+                            secondEntry.getKey(), secondIndex, matchLength));
+                }
+            }
+        }
+        return matches;
+    }
+
+    private static int determineMatchLength(List<String> firstTokens, List<String> secondTokens, int firstIndex,
+            int secondIndex) {
+        int length = 0;
+        while (firstIndex + length < firstTokens.size() && secondIndex + length < secondTokens.size()
+                && firstTokens.get(firstIndex + length).equals(secondTokens.get(secondIndex + length))) {
+            length++;
+        }
+        return length;
+    }
+
+    private static boolean isStartOfMatch(List<String> firstTokens, List<String> secondTokens, int firstIndex,
+            int secondIndex) {
+        if (firstIndex == 0 || secondIndex == 0) {
+            return true;
+        }
+        return !firstTokens.get(firstIndex - 1).equals(secondTokens.get(secondIndex - 1));
     }
 
     private Result storeText(String identifier, Path source, String content) {

--- a/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
+++ b/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
@@ -85,10 +85,7 @@ public enum TokenizationStrategy {
 
         private static boolean isWordConnector(String text, int index) {
             char connector = text.charAt(index);
-            if (connector != APOSTROPHE && connector != HYPHEN_MINUS) {
-                return false;
-            }
-            if (index == 0 || index >= text.length() - 1) {
+            if (connector != APOSTROPHE && connector != HYPHEN_MINUS || index == 0 || index >= text.length() - 1){
                 return false;
             }
             char previous = text.charAt(index - 1);

--- a/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
+++ b/src/edu/kit/kastel/filesorter/model/TokenizationStrategy.java
@@ -85,7 +85,7 @@ public enum TokenizationStrategy {
 
         private static boolean isWordConnector(String text, int index) {
             char connector = text.charAt(index);
-            if (connector != APOSTROPHE && connector != HYPHEN_MINUS || index == 0 || index >= text.length() - 1){
+            if (connector != APOSTROPHE && connector != HYPHEN_MINUS || index == 0 || index >= text.length() - 1) {
                 return false;
             }
             char previous = text.charAt(index - 1);

--- a/src/edu/kit/kastel/filesorter/view/command/Analyze.java
+++ b/src/edu/kit/kastel/filesorter/view/command/Analyze.java
@@ -7,6 +7,8 @@ import edu.kit.kastel.filesorter.view.Result;
 
 /**
  * Command that triggers a text analysis for all loaded texts in the {@link SequenceMatcher}.
+ *
+ * @author ugsrv
  */
 public class Analyze implements Command<SequenceMatcher> {
 

--- a/src/edu/kit/kastel/filesorter/view/command/Analyze.java
+++ b/src/edu/kit/kastel/filesorter/view/command/Analyze.java
@@ -1,0 +1,31 @@
+package edu.kit.kastel.filesorter.view.command;
+
+import edu.kit.kastel.filesorter.model.SequenceMatcher;
+import edu.kit.kastel.filesorter.model.TokenizationStrategy;
+import edu.kit.kastel.filesorter.view.Command;
+import edu.kit.kastel.filesorter.view.Result;
+
+/**
+ * Command that triggers a text analysis for all loaded texts in the {@link SequenceMatcher}.
+ */
+public class Analyze implements Command<SequenceMatcher> {
+
+    private final TokenizationStrategy strategy;
+    private final int minMatchLength;
+
+    /**
+     * Creates a new command instance.
+     *
+     * @param strategy the strategy to use for tokenizing the texts prior to the analysis
+     * @param minMatchLength the minimum length a match must have to be considered
+     */
+    public Analyze(TokenizationStrategy strategy, int minMatchLength) {
+        this.strategy = strategy;
+        this.minMatchLength = minMatchLength;
+    }
+
+    @Override
+    public Result execute(SequenceMatcher handle) {
+        return handle.analyze(this.strategy, this.minMatchLength);
+    }
+}

--- a/src/edu/kit/kastel/filesorter/view/command/ModelKeyword.java
+++ b/src/edu/kit/kastel/filesorter/view/command/ModelKeyword.java
@@ -2,7 +2,6 @@ package edu.kit.kastel.filesorter.view.command;
 
 import edu.kit.kastel.filesorter.model.SequenceMatcher;
 import edu.kit.kastel.filesorter.model.TokenizationStrategy;
-
 import edu.kit.kastel.filesorter.view.Arguments;
 import edu.kit.kastel.filesorter.view.Command;
 import edu.kit.kastel.filesorter.view.CommandProvider;
@@ -32,7 +31,12 @@ public enum ModelKeyword implements Keyword<SequenceMatcher> {
     /**
      * Keyword for the {@link Tokenization} command.
      */
-    TOKENIZATION(arguments -> new Tokenization(arguments.parseString(), parseTokenizationStrategy(arguments)));
+    TOKENIZATION(arguments -> new Tokenization(arguments.parseString(), parseTokenizationStrategy(arguments))),
+
+    /**
+     * Keyword for the {@link Analyze} command.
+     */
+    ANALYZE(arguments -> new Analyze(parseTokenizationStrategy(arguments), arguments.parsePositive()));
 
     private static final String ERROR_INVALID_PATH = "invalid path";
     private static final String ERROR_INVALID_STRATEGY = "invalid strategy";


### PR DESCRIPTION
## Summary
- add immutable model structures for storing analysis tokenizations and matches
- implement model support for running analyses with configurable strategies and minimum match lengths
- register a CLI analyze command that triggers the model analysis via the new keyword
- document the analyze command in the README so users know how to run it

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download plugins because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d069fd6aec8326ad0f5611fe733f46